### PR TITLE
Add merchandise tracking (EATpView, EATpClick)

### DIFF
--- a/Example/Demo Objc/ViewController.m
+++ b/Example/Demo Objc/ViewController.m
@@ -18,11 +18,42 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    [EAnalytics initWithHost:@"ett.eulerian.net" andWithDebugLogs:YES];
-    
+
+    [EAnalytics initWithHost:@"dem.eulerian.net" andWithDebugLogs:YES];
+
     NSLog(@"euidl : %@", [EAnalytics euidl]);
     NSLog(@"EAnalytics version : %@", [EAnalytics version]);
+
+    [self installDemoButtons];
+}
+
+- (void)installDemoButtons
+{
+    UIStackView *stack = [[UIStackView alloc] init];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 12.0;
+    stack.alignment = UIStackViewAlignmentFill;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:stack];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:24],
+        [stack.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-24],
+        [stack.topAnchor constraintEqualToAnchor:self.view.topAnchor constant:80]
+    ]];
+
+    NSArray<NSDictionary *> *buttons = @[
+        @{ @"title": @"PROPERTIES (with action)", @"sel": NSStringFromSelector(@selector(onClickProperties:)) },
+        @{ @"title": @"ACTION",                   @"sel": NSStringFromSelector(@selector(onClickAction:)) },
+        @{ @"title": @"TP VIEW",                  @"sel": NSStringFromSelector(@selector(onClickTpView:)) },
+        @{ @"title": @"TP CLICK",                 @"sel": NSStringFromSelector(@selector(onClickTpClick:)) }
+    ];
+    for (NSDictionary *def in buttons) {
+        UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
+        [b setTitle:def[@"title"] forState:UIControlStateNormal];
+        [b addTarget:self action:NSSelectorFromString(def[@"sel"]) forControlEvents:UIControlEventTouchUpInside];
+        [stack addArrangedSubview:b];
+    }
 }
 
 - (void)didReceiveMemoryWarning
@@ -54,6 +85,97 @@
     [action setEulerianWithInValue:@"my_in_value"];
     [action setEulerianWithRef:@"my_action_ref"];
     [action setEulerianWithOutValues:@[@"my_out_0", @"my_out_1", @"my_out_2" ]];
+    return action;
+}
+
+#pragma mark - Demo handlers (ported from Android)
+
+- (IBAction)onClickProperties:(id)sender
+{
+    EAProperties *prop = [[EAProperties alloc] initWithPath:@"the_path"];
+    [prop setEulerianWithEmail:@"test-email"];
+    [prop setEulerianWithPageGroup:@"test-group"];
+    [prop setEulerianWithProfile:@"test-profile"];
+    [prop setEulerianWithUid:@"test-uid"];
+    [prop setEulerianWithValue:@"..." forKey:@"whatever"];
+
+    [prop addEulerianWithAction:[self buildActionWithName:@"test-action-andrea-properties-1"
+                                                      ref:@"ref-XXX"
+                                                     mode:@"in"
+                                                    label:@"lb1,lb2,lb3"
+                                                   params:@{ @"provenance": @"martinique", @"couleur": @"jaune" }]];
+    [prop addEulerianWithAction:[self buildActionWithName:@"test-action-andrea-properties-2"
+                                                      ref:@"test-action-andrea-properties-2"
+                                                     mode:@"out"
+                                                    label:@"lb4,lb5,lb6"
+                                                   params:@{ @"couleur": @"jaune" }]];
+
+    [EAnalytics track:prop];
+}
+
+- (IBAction)onClickAction:(id)sender
+{
+    EAProperties *prop = [[EAProperties alloc] initWithPath:@"the_path"];
+    [prop setEulerianStandalone];
+    [prop setEulerianWithEmail:@"test-email"];
+    [prop setEulerianWithPageGroup:@"test-group"];
+    [prop setEulerianWithProfile:@"test-profile"];
+    [prop setEulerianWithUid:@"test-uid"];
+
+    [prop addEulerianWithAction:[self buildActionWithName:@"test-action-andrea-1"
+                                                      ref:@"ref-XXX"
+                                                     mode:@"in"
+                                                    label:@"lb1,lb2,lb3"
+                                                   params:@{ @"provenance": @"martinique", @"couleur": @"jaune" }]];
+    [prop addEulerianWithAction:[self buildActionWithName:@"test-action-andrea-2"
+                                                      ref:@"test-action-andrea-2"
+                                                     mode:@"out"
+                                                    label:@"lb4,lb5,lb6"
+                                                   params:@{ @"couleur": @"jaune" }]];
+
+    [EAnalytics track:prop];
+}
+
+- (IBAction)onClickTpView:(id)sender
+{
+    EATpView *view = [[EATpView alloc] initWithPath:@"homepage"];
+    [view setSiteName:@"admin-andrea2"];
+    [view setCampaign:@"summer_sale"];
+    [view setPlacement:@"banner_top"];
+    [view addProductWithRef:@"PROD_001" position:@(0)];
+    [view addProductWithRef:@"PROD_002" position:@(1)];
+    [view setUrl:@"http://eulerian.net"];
+    [EAnalytics track:view];
+}
+
+- (IBAction)onClickTpClick:(id)sender
+{
+    EATpClick *click = [[EATpClick alloc] initWithPath:@"homepage"];
+    [click setSiteName:@"admin-andrea2"];
+    [click setCampaign:@"summer_sale"];
+    [click setPlacement:@"banner_top"];
+    [click setProductWithRef:@"PROD_001" position:2];
+    [click setUrl:@"http://eulerian.net"];
+    [EAnalytics track:click];
+}
+
+- (EAOAction *)buildActionWithName:(NSString *)name
+                               ref:(NSString *)ref
+                              mode:(NSString *)mode
+                             label:(NSString *)label
+                            params:(NSDictionary<NSString *, NSString *> *)params
+{
+    EAOAction *action = [[EAOAction alloc] init];
+    [action setEulerianWithName:name];
+    [action setEulerianWithRef:ref];
+    [action setEulerianWithMode:mode];
+    [action setEulerianWithLabel:label];
+
+    EAOParams *p = [[EAOParams alloc] init];
+    [params enumerateKeysAndObjectsUsingBlock:^(NSString *k, NSString *v, BOOL *stop) {
+        [p setEulerianWithStringValue:v forKey:k];
+    }];
+    [action setEulerianWithParams:p];
     return action;
 }
 

--- a/Pod/Classes/EAOAction.h
+++ b/Pod/Classes/EAOAction.h
@@ -7,14 +7,24 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "EAOParams.h"
 
 @interface EAOAction : NSObject
 
 @property (readonly) NSMutableDictionary* dictionary;
 
 - (void)setEulerianWithRef:(NSString *) value;
-- (void)setEulerianWithInValue:(NSString *) value;
-- (void)setEulerianWithOutValues:(NSArray *) values;
+
+// New API (mirrors Android Action.Builder)
+- (void)setEulerianWithName:(NSString *)value;
+- (void)setEulerianWithMode:(NSString *)value;
+- (void)setEulerianWithLabel:(NSString *)value;
+- (void)setEulerianWithParams:(EAOParams *)value;
+
+// Legacy API — kept for backward compatibility, prefer the new methods above.
+- (void)setEulerianWithInValue:(NSString *) value     __attribute__((deprecated("Use -setEulerianWithMode: with @\"in\" + -setEulerianWithLabel:")));
+- (void)setEulerianWithOutValues:(NSArray *) values   __attribute__((deprecated("Use -setEulerianWithMode: with @\"out\" + -setEulerianWithLabel:")));
+
 - (void)checkConformity;
 
 @end

--- a/Pod/Classes/EAOAction.m
+++ b/Pod/Classes/EAOAction.m
@@ -15,6 +15,11 @@ static NSString* const KEY_REF = @"ref";
 static NSString* const KEY_IN = @"in";
 static NSString* const KEY_OUT = @"out";
 
+static NSString* const KEY_NAME = @"name";
+static NSString* const KEY_MODE = @"mode";
+static NSString* const KEY_LABEL = @"label";
+static NSString* const KEY_PARAMS = @"params";
+
 - (instancetype)init
 {
     self = [super init];
@@ -29,6 +34,29 @@ static NSString* const KEY_OUT = @"out";
     [_dictionary setObject:value forKey:KEY_REF];
 }
 
+- (void)setEulerianWithName:(NSString *)value
+{
+    [_dictionary setObject:value forKey:KEY_NAME];
+}
+
+- (void)setEulerianWithMode:(NSString *)value
+{
+    [_dictionary setObject:value forKey:KEY_MODE];
+}
+
+- (void)setEulerianWithLabel:(NSString *)value
+{
+    [_dictionary setObject:value forKey:KEY_LABEL];
+}
+
+- (void)setEulerianWithParams:(EAOParams *)value
+{
+    [_dictionary setObject:value.dictionary forKey:KEY_PARAMS];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 - (void)setEulerianWithInValue:(NSString *) value
 {
     [_dictionary setObject:value forKey:KEY_IN];
@@ -39,11 +67,16 @@ static NSString* const KEY_OUT = @"out";
     [_dictionary setObject:values forKey:KEY_OUT];
 }
 
+#pragma clang diagnostic pop
+
 - (void)checkConformity
 {
+    id hasMode = [_dictionary objectForKey:KEY_MODE];
     id hasIn = [_dictionary objectForKey:KEY_IN];
     id hasOut = [_dictionary objectForKey:KEY_OUT];
-    [EAAssertion warnCondition:(hasIn && hasOut) withMessage:@"EAAction must contain both 'in' and 'out' keys to be valid."];
+    BOOL legacyValid = (hasIn || hasOut);
+    BOOL newValid = (hasMode != nil);
+    [EAAssertion warnCondition:(newValid || legacyValid) withMessage:@"EAAction must contain 'mode' (preferred) or 'in'/'out' (legacy) keys to be valid."];
 }
 
 @end

--- a/Pod/Classes/EAProperties.h
+++ b/Pod/Classes/EAProperties.h
@@ -28,8 +28,10 @@
 - (void)setEulerianWithPageGroup:(NSString*)value;
 - (void)setEulerianWithNewCustomer:(BOOL)value;
 - (void)setEulerianWithAction:(EAOAction*)value;
+- (void)addEulerianWithAction:(EAOAction*)value;
 - (void)setEulerianWithProperties:(EAOSiteCentricProperties*)value;
 - (void)setEulerianWithCFlag:(EAOSiteCentricCFlag*)value;
+- (void)setEulerianStandalone;
 - (void)setEulerianWithValue:(id)value forKey:(NSString *)key;
 
 @end

--- a/Pod/Classes/EAProperties.m
+++ b/Pod/Classes/EAProperties.m
@@ -36,6 +36,8 @@ static NSString* const KEY_PAGE_UID = @"uid";
 static NSString* const KEY_PAGE_PROFILE = @"profile";
 static NSString* const KEY_PAGE_GROUP = @"pagegroup";
 static NSString* const KEY_PAGE_ACTION = @"action";
+static NSString* const KEY_PAGE_ACTIONS = @"actions";
+static NSString* const KEY_PAGE_STANDALONE = @"ereplay-notag";
 static NSString* const KEY_PAGE_PROPERTY = @"property";
 static NSString* const KEY_PAGE_CFLAG = @"cflag";
 static NSString* const KEY_PAGE_NEW_CUSTOMER = @"newcustomer";
@@ -141,6 +143,22 @@ static NSString* const KEY_PAGE_NEW_CUSTOMER = @"newcustomer";
 {
     [value checkConformity];
     [_dictionary setObject:value.dictionary forKey:KEY_PAGE_ACTION];
+}
+
+- (void)addEulerianWithAction:(EAOAction *)value
+{
+    [value checkConformity];
+    NSMutableArray *actions = [_dictionary objectForKey:KEY_PAGE_ACTIONS];
+    if (![actions isKindOfClass:[NSMutableArray class]]) {
+        actions = [NSMutableArray array];
+        [_dictionary setObject:actions forKey:KEY_PAGE_ACTIONS];
+    }
+    [actions addObject:value.dictionary];
+}
+
+- (void)setEulerianStandalone
+{
+    [_dictionary setObject:@(1) forKey:KEY_PAGE_STANDALONE];
 }
 
 - (void)setEulerianWithProperties:(EAOSiteCentricProperties*)value

--- a/Pod/Classes/EATpClick.h
+++ b/Pod/Classes/EATpClick.h
@@ -1,0 +1,28 @@
+//
+//  EATpClick.h
+//  EAnalytics
+//
+//  Ported from eanalytics-android.
+//
+
+#import <Foundation/Foundation.h>
+#import "EAProperties.h"
+
+@interface EATpClick : EAProperties
+
+- (instancetype)initWithPath:(NSString *)path;
+
+- (void)setSiteName:(NSString *)value;
+- (void)setCampaign:(NSString *)value;
+- (void)setPlacement:(NSString *)value;
+- (void)setPublisher:(NSString *)value;
+- (void)setMedia:(NSString *)value;
+- (void)setCategory:(NSString *)value;
+- (void)setUrl:(NSString *)value;
+
+- (void)setProductWithRef:(NSString *)ref position:(NSInteger)position;
+- (void)setProductWithRef:(NSString *)ref position:(NSInteger)position totalProducts:(NSNumber *)totalProducts;
+
+- (NSString *)toQueryString;
+
+@end

--- a/Pod/Classes/EATpClick.m
+++ b/Pod/Classes/EATpClick.m
@@ -1,0 +1,136 @@
+//
+//  EATpClick.m
+//  EAnalytics
+//
+//  Ported from eanalytics-android.
+//
+
+#import "EATpClick.h"
+
+static NSString *const KEY_TYPE = @"type";
+static NSString *const TYPE_VALUE = @"EATpClick";
+
+static NSString *const KEY_DYNTPCLICK = @"dyntpclick";
+static NSString *const KEY_TPCLICKPRODUCT = @"tpclickproduct";
+
+static NSString *const KEY_PRODUCT_REF = @"ecprdr";
+static NSString *const KEY_PRODUCT_POS = @"ecpos";
+static NSString *const KEY_TOTAL_PRODUCT = @"ecnbr";
+
+@interface EATpClick ()
+
+@property (nonatomic, copy) NSString *siteName;
+@property (nonatomic, copy) NSString *campaignName;
+@property (nonatomic, copy) NSString *placement;
+@property (nonatomic, copy) NSString *publisher;
+@property (nonatomic, copy) NSString *media;
+@property (nonatomic, copy) NSString *category;
+@property (nonatomic, copy) NSString *url;
+
+@property (nonatomic, copy) NSString *productRef;
+@property (nonatomic, assign) NSInteger productPosition;
+@property (nonatomic, strong) NSNumber *productTotal;
+
+@end
+
+@implementation EATpClick
+
+- (instancetype)initWithPath:(NSString *)path
+{
+    self = [super initWithPath:path];
+    if (self) {
+        _siteName = @"";
+        _campaignName = @"";
+        _placement = @"";
+        _publisher = @"";
+        _media = @"";
+        _category = @"";
+        _url = @"";
+        _productRef = @"";
+        _productPosition = 0;
+        _productTotal = nil;
+        [self.dictionary setObject:TYPE_VALUE forKey:KEY_TYPE];
+        [self syncDictionary];
+    }
+    return self;
+}
+
+- (void)setSiteName:(NSString *)value     { _siteName     = [value copy]; [self syncDictionary]; }
+- (void)setCampaign:(NSString *)value     { _campaignName = [value copy]; [self syncDictionary]; }
+- (void)setPlacement:(NSString *)value    { _placement    = [value copy]; [self syncDictionary]; }
+- (void)setPublisher:(NSString *)value    { _publisher    = [value copy]; [self syncDictionary]; }
+- (void)setMedia:(NSString *)value        { _media        = [value copy]; [self syncDictionary]; }
+- (void)setCategory:(NSString *)value     { _category     = [value copy]; [self syncDictionary]; }
+- (void)setUrl:(NSString *)value          { _url          = [value copy]; [self syncDictionary]; }
+
+- (void)setProductWithRef:(NSString *)ref position:(NSInteger)position
+{
+    [self setProductWithRef:ref position:position totalProducts:nil];
+}
+
+- (void)setProductWithRef:(NSString *)ref position:(NSInteger)position totalProducts:(NSNumber *)totalProducts
+{
+    _productRef = [ref copy];
+    _productPosition = position;
+    _productTotal = totalProducts;
+    [self syncDictionary];
+}
+
+- (void)syncDictionary
+{
+    NSMutableDictionary *product = [NSMutableDictionary dictionary];
+    [product setObject:(_productRef ?: @"") forKey:@"ref"];
+    [product setObject:@(_productPosition) forKey:@"position"];
+    if (_productTotal) {
+        [product setObject:_productTotal forKey:@"totalProducts"];
+    }
+
+    NSArray *dyntpclick = @[
+        _siteName ?: @"",
+        _campaignName ?: @"",
+        _placement ?: @"",
+        _publisher ?: @"",
+        _media ?: @"",
+        _category ?: @"",
+        product
+    ];
+    [self.dictionary setObject:dyntpclick forKey:KEY_DYNTPCLICK];
+    [self.dictionary setObject:product forKey:KEY_TPCLICKPRODUCT];
+}
+
+- (NSString *)toQueryString
+{
+    uint32_t randomNum = arc4random_uniform(1000000000);
+
+    NSMutableString *query = [NSMutableString string];
+    [query appendFormat:@"%@/%@/%@/%@/generic/%u?",
+        [self encode:_siteName],
+        [self encode:_campaignName],
+        [self encode:_placement],
+        [self encode:_siteName],
+        randomNum];
+
+    [query appendFormat:@"%@=%@&", KEY_PRODUCT_REF, [self encode:_productRef]];
+    [query appendFormat:@"%@=%@&", KEY_PRODUCT_POS, [self encode:[@(_productPosition) stringValue]]];
+
+    if (_productTotal) {
+        [query appendFormat:@"%@=%@&", KEY_TOTAL_PRODUCT, [self encode:[_productTotal stringValue]]];
+    }
+
+    if (_url.length > 0) {
+        [query appendFormat:@"url=%@&", [self encode:_url]];
+    }
+
+    return [query copy];
+}
+
+- (NSString *)encode:(NSString *)value
+{
+    if (value == nil) {
+        return @"";
+    }
+    NSCharacterSet *allowed = [NSCharacterSet URLQueryAllowedCharacterSet];
+    return [value stringByAddingPercentEncodingWithAllowedCharacters:allowed] ?: @"";
+}
+
+@end

--- a/Pod/Classes/EATpView.h
+++ b/Pod/Classes/EATpView.h
@@ -1,0 +1,27 @@
+//
+//  EATpView.h
+//  EAnalytics
+//
+//  Ported from eanalytics-android.
+//
+
+#import <Foundation/Foundation.h>
+#import "EAProperties.h"
+
+@interface EATpView : EAProperties
+
+- (instancetype)initWithPath:(NSString *)path;
+
+- (void)setSiteName:(NSString *)value;
+- (void)setCampaign:(NSString *)value;
+- (void)setPlacement:(NSString *)value;
+- (void)setPublisher:(NSString *)value;
+- (void)setMedia:(NSString *)value;
+- (void)setCategory:(NSString *)value;
+- (void)setUrl:(NSString *)value;
+
+- (void)addProductWithRef:(NSString *)ref position:(NSNumber *)position;
+
+- (NSString *)toQueryString;
+
+@end

--- a/Pod/Classes/EATpView.m
+++ b/Pod/Classes/EATpView.m
@@ -1,0 +1,123 @@
+//
+//  EATpView.m
+//  EAnalytics
+//
+//  Ported from eanalytics-android.
+//
+
+#import "EATpView.h"
+
+static NSString *const KEY_TYPE = @"type";
+static NSString *const TYPE_VALUE = @"EATpView";
+
+static NSString *const KEY_DYNTPVIEW = @"dyntpview";
+static NSString *const KEY_TPVIEWPRD = @"tpviewprd";
+
+@interface EATpView ()
+
+@property (nonatomic, copy) NSString *siteName;
+@property (nonatomic, copy) NSString *campaignName;
+@property (nonatomic, copy) NSString *placement;
+@property (nonatomic, copy) NSString *publisher;
+@property (nonatomic, copy) NSString *media;
+@property (nonatomic, copy) NSString *category;
+@property (nonatomic, copy) NSString *url;
+
+@property (nonatomic, strong) NSMutableArray<NSArray *> *tpviewProducts;
+
+@end
+
+@implementation EATpView
+
+- (instancetype)initWithPath:(NSString *)path
+{
+    self = [super initWithPath:path];
+    if (self) {
+        _siteName = @"";
+        _campaignName = @"";
+        _placement = @"";
+        _publisher = @"";
+        _media = @"";
+        _category = @"";
+        _url = @"";
+        _tpviewProducts = [NSMutableArray array];
+        [self.dictionary setObject:TYPE_VALUE forKey:KEY_TYPE];
+        [self syncDictionary];
+    }
+    return self;
+}
+
+- (void)setSiteName:(NSString *)value     { _siteName     = [value copy]; [self syncDictionary]; }
+- (void)setCampaign:(NSString *)value     { _campaignName = [value copy]; [self syncDictionary]; }
+- (void)setPlacement:(NSString *)value    { _placement    = [value copy]; [self syncDictionary]; }
+- (void)setPublisher:(NSString *)value    { _publisher    = [value copy]; [self syncDictionary]; }
+- (void)setMedia:(NSString *)value        { _media        = [value copy]; [self syncDictionary]; }
+- (void)setCategory:(NSString *)value     { _category     = [value copy]; [self syncDictionary]; }
+- (void)setUrl:(NSString *)value          { _url          = [value copy]; [self syncDictionary]; }
+
+- (void)addProductWithRef:(NSString *)ref position:(NSNumber *)position
+{
+    NSMutableArray *prod = [NSMutableArray array];
+    [prod addObject:(ref ?: @"")];
+    if (position) {
+        [prod addObject:position];
+    }
+    [_tpviewProducts addObject:prod];
+    [self syncDictionary];
+}
+
+- (void)syncDictionary
+{
+    NSArray *dyntpview = @[
+        _siteName ?: @"",
+        _campaignName ?: @"",
+        _placement ?: @"",
+        _publisher ?: @"",
+        _media ?: @"",
+        _category ?: @"",
+        _url ?: @""
+    ];
+    [self.dictionary setObject:dyntpview forKey:KEY_DYNTPVIEW];
+    [self.dictionary setObject:_tpviewProducts forKey:KEY_TPVIEWPRD];
+}
+
+- (NSString *)toQueryString
+{
+    uint32_t randomNum = arc4random_uniform(1000000000);
+
+    NSMutableString *query = [NSMutableString string];
+    [query appendFormat:@"%@/%@/%@/%@/generic/%u?",
+        [self encode:_siteName],
+        [self encode:_campaignName],
+        [self encode:_placement],
+        [self encode:_siteName],
+        randomNum];
+
+    for (NSUInteger i = 0; i < _tpviewProducts.count; i++) {
+        NSArray *prod = _tpviewProducts[i];
+        NSString *ref = prod.count > 0 ? [prod[0] description] : @"";
+        id pos = prod.count > 1 ? prod[1] : nil;
+
+        [query appendFormat:@"evprdr%lu=%@&", (unsigned long)i, [self encode:ref]];
+        if (pos) {
+            [query appendFormat:@"evprdpos%lu=%@&", (unsigned long)i, [pos description]];
+        }
+    }
+
+    if (_url.length > 0) {
+        [query appendFormat:@"url=%@&", [self encode:_url]];
+    }
+
+    return [query copy];
+}
+
+- (NSString *)encode:(NSString *)value
+{
+    if (value == nil) {
+        return @"";
+    }
+    NSCharacterSet *allowed = [NSCharacterSet URLQueryAllowedCharacterSet];
+    return [value stringByAddingPercentEncodingWithAllowedCharacters:allowed] ?: @"";
+}
+
+@end

--- a/Pod/Classes/EAnalytics.h
+++ b/Pod/Classes/EAnalytics.h
@@ -21,6 +21,8 @@
 #import "EAProducts.h"
 #import "EAProperties.h"
 #import "EASearch.h"
+#import "EATpClick.h"
+#import "EATpView.h"
 
 @interface EAnalytics : NSObject {
     

--- a/Pod/Classes/EAnalytics.m
+++ b/Pod/Classes/EAnalytics.m
@@ -11,6 +11,8 @@
 #import "EAAssertion.h"
 #import "Utils.h"
 #import "NSData+GZIP.h"
+#import "EATpClick.h"
+#import "EATpView.h"
 
 @implementation EAnalytics
 
@@ -21,9 +23,14 @@ static NSString* const USER_DEFAULT_LOOKUP_SENT = @"eulerian-lookup-already-sent
 static NSString* const KEY_LOOKUP = @"ea-uid-lookup";
 static NSString* const KEY_GLOBAL_EUIDL = @"euidl";
 static NSString* const KEY_GLOBAL_SDK_VERSION = @"ea-ios-sdk-version";
+static NSString* const KEY_TYPE = @"type";
+static NSString* const TYPE_TPVIEW = @"EATpView";
+static NSString* const TYPE_TPCLICK = @"EATpClick";
 
 static BOOL sDebug;
 static NSString *sSTDomain;
+static NSString *sClickDomain;
+static NSString *sViewDomain;
 
 dispatch_queue_t serialQueue;
 
@@ -55,30 +62,59 @@ dispatch_queue_t serialQueue;
     NSLog(@"EULERIAN ANALYTICS : initialized with %@. Running lib v%@. %@.", host, [EAnalytics version], adSupportDetectedMsg);
     sDebug = debug;
     sSTDomain = [NSString stringWithFormat:@"https://%@/collectorjson/-/", host];
+    sClickDomain = [NSString stringWithFormat:@"https://%@/tpclick/", host];
+    sViewDomain = [NSString stringWithFormat:@"https://%@/tpview/", host];
     serialQueue = dispatch_queue_create("com.eulerian.serial.queue", DISPATCH_QUEUE_SERIAL);
-    
+
     [self checkForStoredProperties];
 }
 
 + (void)checkForStoredProperties
 {
     dispatch_async(serialQueue, ^{
-        //block
         NSArray* untracked = [[NSUserDefaults standardUserDefaults] arrayForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
-        if ([untracked count]>0) {
+        if ([untracked count] == 0) {
             if (sDebug) {
-                NSLog(@"EULERIAN ANALYTICS : %d stored properties found. Will try to send them.", (int) [untracked count]);
+                NSLog(@"EULERIAN ANALYTICS : No stored properties found. Continue.");
             }
-            BOOL success = [EAnalytics httpPostProperties:untracked];
-            if (success) {
-                [[NSUserDefaults standardUserDefaults] removeObjectForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
-                [[NSUserDefaults standardUserDefaults] synchronize];
-            } else if (sDebug) {
-                NSLog(@"EULERIAN ANALYTICS : Failed to save stored properties. Will retry later.");
-            }
-        } else if (sDebug) {
-            NSLog(@"EULERIAN ANALYTICS : No stored properties found. Continue.");
+            return;
         }
+        if (sDebug) {
+            NSLog(@"EULERIAN ANALYTICS : %d stored properties found. Will try to send them.", (int) [untracked count]);
+        }
+
+        NSMutableArray *genericPending = [NSMutableArray array];
+        NSMutableArray *stillUntracked = [NSMutableArray array];
+
+        for (NSDictionary *entry in untracked) {
+            NSString *type = [entry isKindOfClass:[NSDictionary class]] ? entry[KEY_TYPE] : nil;
+            if ([TYPE_TPVIEW isEqualToString:type] || [TYPE_TPCLICK isEqualToString:type]) {
+                BOOL success = [EAnalytics httpGetTypedEntry:entry];
+                if (!success) {
+                    [stillUntracked addObject:entry];
+                }
+            } else {
+                [genericPending addObject:entry];
+            }
+        }
+
+        if (genericPending.count > 0) {
+            BOOL success = [EAnalytics httpPostProperties:genericPending];
+            if (!success) {
+                [stillUntracked addObjectsFromArray:genericPending];
+            }
+        }
+
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        if (stillUntracked.count > 0) {
+            [defaults setObject:stillUntracked forKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+            if (sDebug) {
+                NSLog(@"EULERIAN ANALYTICS : %d stored properties still pending. Will retry later.", (int)stillUntracked.count);
+            }
+        } else {
+            [defaults removeObjectForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+        }
+        [defaults synchronize];
     });
 }
 
@@ -87,7 +123,7 @@ dispatch_queue_t serialQueue;
     dispatch_async(serialQueue, ^{
         [properties setEulerianWithValue:[EAnalytics euidl] forKey:KEY_GLOBAL_EUIDL];
         [properties setEulerianWithValue:[EAnalytics version] forKey:KEY_GLOBAL_SDK_VERSION];
-        //block
+
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         if ([defaults boolForKey:USER_DEFAULT_LOOKUP_SENT]) {
             [properties setEulerianWithValue:[NSNumber numberWithInt:1] forKey: KEY_LOOKUP];
@@ -98,46 +134,201 @@ dispatch_queue_t serialQueue;
             NSString *log = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
             NSLog(@"EULERIAN ANALYTICS : Tracking :%@", log);
         }
+
+        BOOL isTpView = [properties isKindOfClass:[EATpView class]];
+        BOOL isTpClick = [properties isKindOfClass:[EATpClick class]];
+
+        if (isTpView || isTpClick) {
+            BOOL success = [EAnalytics httpGetForProperties:properties];
+            if (success) {
+                if (sDebug) NSLog(@"EULERIAN ANALYTICS : Track succeeded.");
+            } else {
+                if (sDebug) NSLog(@"EULERIAN ANALYTICS : Track failed. Will retry later.");
+                [EAnalytics appendUntracked:properties.dictionary];
+            }
+            return;
+        }
+
+        // Generic event: batch with previously untracked
         NSMutableArray *track = [NSMutableArray arrayWithObject:properties.dictionary];
         NSArray* untracked = [defaults arrayForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+        NSMutableArray *carriedTyped = [NSMutableArray array];
         if (untracked) {
-            if (sDebug) {
-                NSLog(@"add %d stored properties to the current track.", (int)[untracked count]);
+            for (NSDictionary *entry in untracked) {
+                NSString *type = [entry isKindOfClass:[NSDictionary class]] ? entry[KEY_TYPE] : nil;
+                if ([TYPE_TPVIEW isEqualToString:type] || [TYPE_TPCLICK isEqualToString:type]) {
+                    [carriedTyped addObject:entry];
+                } else {
+                    [track addObject:entry];
+                }
             }
-            [track addObjectsFromArray:untracked];
+            if (sDebug && (track.count - 1) > 0) {
+                NSLog(@"add %d stored properties to the current track.", (int)(track.count - 1));
+            }
         }
         BOOL success = [EAnalytics httpPostProperties:track];
         if (success) {
-            if (sDebug) {
-                NSLog(@"EULERIAN ANALYTICS : Track succeeded.");
+            if (sDebug) NSLog(@"EULERIAN ANALYTICS : Track succeeded.");
+            if (carriedTyped.count > 0) {
+                [defaults setObject:carriedTyped forKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+            } else {
+                [defaults removeObjectForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
             }
-            [defaults removeObjectForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
         } else {
-            if (sDebug) {
-                NSLog(@"EULERIAN ANALYTICS : Track failed. Will retry later.");
-            }
-            [defaults setObject:track forKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+            if (sDebug) NSLog(@"EULERIAN ANALYTICS : Track failed. Will retry later.");
+            NSMutableArray *toStore = [NSMutableArray arrayWithArray:track];
+            [toStore addObjectsFromArray:carriedTyped];
+            [defaults setObject:toStore forKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
         }
         [defaults synchronize];
     });
+}
+
++ (void)appendUntracked:(NSDictionary *)entry
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSArray *current = [defaults arrayForKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+    NSMutableArray *next = current ? [current mutableCopy] : [NSMutableArray array];
+    [next addObject:entry];
+    [defaults setObject:next forKey:USER_DEFAULT_UNTRACKED_PROPERTIES_ARRAY];
+    [defaults synchronize];
+}
+
++ (BOOL)httpGetForProperties:(EAProperties *)properties
+{
+    NSString *base = nil;
+    NSString *query = nil;
+    if ([properties isKindOfClass:[EATpView class]]) {
+        base = sViewDomain;
+        query = [(EATpView *)properties toQueryString];
+    } else if ([properties isKindOfClass:[EATpClick class]]) {
+        base = sClickDomain;
+        query = [(EATpClick *)properties toQueryString];
+    } else {
+        return NO;
+    }
+    return [EAnalytics performHttpGetWithBase:base query:query];
+}
+
++ (BOOL)httpGetTypedEntry:(NSDictionary *)entry
+{
+    NSString *type = entry[KEY_TYPE];
+    EAProperties *restored = nil;
+    if ([TYPE_TPVIEW isEqualToString:type]) {
+        restored = [EAnalytics restoreEATpView:entry];
+    } else if ([TYPE_TPCLICK isEqualToString:type]) {
+        restored = [EAnalytics restoreEATpClick:entry];
+    }
+    if (restored == nil) {
+        return NO;
+    }
+    return [EAnalytics httpGetForProperties:restored];
+}
+
++ (EATpView *)restoreEATpView:(NSDictionary *)entry
+{
+    NSString *path = entry[@"path"] ?: @"/";
+    EATpView *v = [[EATpView alloc] initWithPath:path];
+    NSArray *dyntpview = entry[@"dyntpview"];
+    if ([dyntpview isKindOfClass:[NSArray class]] && dyntpview.count >= 7) {
+        [v setSiteName:[dyntpview[0] description]];
+        [v setCampaign:[dyntpview[1] description]];
+        [v setPlacement:[dyntpview[2] description]];
+        [v setPublisher:[dyntpview[3] description]];
+        [v setMedia:[dyntpview[4] description]];
+        [v setCategory:[dyntpview[5] description]];
+        [v setUrl:[dyntpview[6] description]];
+    }
+    NSArray *products = entry[@"tpviewprd"];
+    if ([products isKindOfClass:[NSArray class]]) {
+        for (NSArray *prod in products) {
+            if (![prod isKindOfClass:[NSArray class]] || prod.count == 0) continue;
+            NSString *ref = [prod[0] description];
+            NSNumber *pos = prod.count > 1 && [prod[1] isKindOfClass:[NSNumber class]] ? prod[1] : nil;
+            [v addProductWithRef:ref position:pos];
+        }
+    }
+    return v;
+}
+
++ (EATpClick *)restoreEATpClick:(NSDictionary *)entry
+{
+    NSString *path = entry[@"path"] ?: @"/";
+    EATpClick *c = [[EATpClick alloc] initWithPath:path];
+    NSArray *dyntpclick = entry[@"dyntpclick"];
+    if ([dyntpclick isKindOfClass:[NSArray class]] && dyntpclick.count >= 6) {
+        [c setSiteName:[dyntpclick[0] description]];
+        [c setCampaign:[dyntpclick[1] description]];
+        [c setPlacement:[dyntpclick[2] description]];
+        [c setPublisher:[dyntpclick[3] description]];
+        [c setMedia:[dyntpclick[4] description]];
+        [c setCategory:[dyntpclick[5] description]];
+    }
+    NSDictionary *product = entry[@"tpclickproduct"];
+    if ([product isKindOfClass:[NSDictionary class]]) {
+        NSString *ref = [product[@"ref"] ?: @"" description];
+        NSInteger position = [product[@"position"] integerValue];
+        NSNumber *total = [product[@"totalProducts"] isKindOfClass:[NSNumber class]] ? product[@"totalProducts"] : nil;
+        [c setProductWithRef:ref position:position totalProducts:total];
+    }
+    return c;
+}
+
++ (BOOL)performHttpGetWithBase:(NSString *)base query:(NSString *)query
+{
+    NSString *urlString = [NSString stringWithFormat:@"%@%@", base, query ?: @""];
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (url == nil) {
+        if (sDebug) NSLog(@"EULERIAN ANALYTICS : Invalid GET URL >>>> %@", urlString);
+        return NO;
+    }
+    if (sDebug) NSLog(@"EULERIAN ANALYTICS : GET >>>> %@", urlString);
+
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    [request setHTTPMethod:@"GET"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [request setTimeoutInterval:5.0];
+
+    __block NSData *responseData = nil;
+    __block NSURLResponse *response = nil;
+    __block NSError *requestError = nil;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    NSURLSession *session = [NSURLSession sharedSession];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData * _Nullable d, NSURLResponse * _Nullable r, NSError * _Nullable e) {
+        responseData = d;
+        response = r;
+        requestError = e;
+        dispatch_semaphore_signal(sema);
+    }];
+    [task resume];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    if (requestError) {
+        if (sDebug) NSLog(@"EULERIAN ANALYTICS : GET request failed >>>> %@", requestError.debugDescription);
+        return NO;
+    }
+    NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]] ? ((NSHTTPURLResponse *)response).statusCode : 0;
+    if (sDebug) NSLog(@"EULERIAN ANALYTICS : GET response status %ld", (long)status);
+    return (status >= 200 && status < 300);
 }
 
 + (BOOL)httpPostProperties:(NSArray*)props
 {
     //Prepare data
     NSData *data = [NSJSONSerialization dataWithJSONObject:props options:0 error:nil];
-    
+
     if (sDebug) {
         NSString *log = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         NSLog(@"EULERIAN ANALYTICS : Posting >>>> %@", log);
     }
-    
+
     NSData *requestBodyData = [data gzippedData];
     NSString *postLength = [NSString stringWithFormat:@"%lu", (unsigned long) requestBodyData.length];
-    
+
     NSString *urlString = [NSString stringWithFormat:@"%@%d", sSTDomain, (int) [NSDate date].timeIntervalSince1970];
     NSURL *url = [NSURL URLWithString:urlString];
-    
+
     //Build Request
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     [request setHTTPMethod:@"POST"];
@@ -145,34 +336,34 @@ dispatch_queue_t serialQueue;
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
     [request setHTTPBody:requestBodyData];
-    
+
     //Send the request
     NSError *requestError;
     NSData *responseData = [NSURLConnection sendSynchronousRequest: request returningResponse: nil error: &requestError];
-    
+
     if (requestError) {
         if (sDebug) {
             NSLog(@"EULERIAN ANALYTICS : Request failed >>>> %@", requestError.debugDescription);
         }
         return NO;
     }
-    
+
     //Get the Result of Request
     NSError *responseError;
     NSDictionary* responseDic = [NSJSONSerialization JSONObjectWithData:responseData options:kNilOptions error:&responseError];
-    
+
     if (responseError) {
         if (sDebug) {
             NSLog(@"EULERIAN ANALYTICS : Read response failed >>>> %@", requestError.debugDescription);
         }
         return NO;
     }
-    
+
     if (sDebug) {
         NSString *log = [[NSString alloc] initWithBytes:[responseData bytes] length:[responseData length] encoding:NSUTF8StringEncoding];
         NSLog(@"EULERIAN ANALYTICS : Response >>>> %@", log);
     }
-    
+
     //Check result
     NSNumber *errorValue = (NSNumber *)[responseDic valueForKey:@"error"];
     return ![errorValue boolValue];


### PR DESCRIPTION
## Summary
- Introduce `EATpView` and `EATpClick`, two `EAProperties` subclasses that emit merchandise tpview / tpclick events via GET on the new `/tpview/` and `/tpclick/` endpoints.
- Refresh `EAOAction` with the new `name` / `mode` / `label` / `params` API; legacy `in` / `out` setters are kept and marked deprecated.
- `EAProperties` gains `addEulerianWithAction:` (multi-action) and `setEulerianStandalone`. `EAnalytics` routes events by class and persists pending typed events with a `type` discriminator so they can be replayed via GET on the next startup.
- Demo Objc gets dedicated buttons (PROPERTIES, ACTION, TP VIEW, TP CLICK) wired to the new flow.

This mirrors the equivalent change recently made on the Android SDK.